### PR TITLE
Added PyTorch 2.x compatibility for future projects' SOTA comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ lib/
 __pycache__/
 *.py[cod]
 _vizdoom.ini
+/dumped

--- a/arnold.py
+++ b/arnold.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 import vizdoom
 from src.utils import get_dump_path
 from src.logger import get_logger
@@ -16,7 +17,10 @@ assert len(args.exp_name.strip()) > 0
 
 # create a directory for the experiment / create a logger
 dump_path = get_dump_path(args.main_dump_path, args.exp_name)
-logger = get_logger(filepath=os.path.join(dump_path, 'train.log'))
+log_path = os.path.join(dump_path, 'train.log')
+if sys.platform == "win32":
+    log_path = log_path.replace('\\', '/')
+logger = get_logger(filepath=log_path)
 logger.info('========== Running DOOM ==========')
 logger.info('Experiment will be saved in: %s' % dump_path)
 

--- a/src/doom/actions.py
+++ b/src/doom/actions.py
@@ -88,9 +88,8 @@ class ActionBuilder(object):
                            for k in self.available_buttons]
             return doom_action
         else:
-            a = action if type(action) == int else int(action.item())
-            assert type(a) is int
-            return self.doom_actions[a]
+            assert type(action) is int
+            return self.doom_actions[action]
 
 
 action_categories_discrete = {

--- a/src/doom/actions.py
+++ b/src/doom/actions.py
@@ -88,8 +88,9 @@ class ActionBuilder(object):
                            for k in self.available_buttons]
             return doom_action
         else:
-            assert type(action) is int
-            return self.doom_actions[action]
+            a = action if type(action) == int else int(action.item())
+            assert type(a) is int
+            return self.doom_actions[a]
 
 
 action_categories_discrete = {

--- a/src/logger.py
+++ b/src/logger.py
@@ -39,6 +39,10 @@ def get_logger(filepath=None):
     log_formatter = LogFormatter()
 
     # create file handler and set level to debug
+    file_dir = os.path.split(filepath)[0]
+    if file_dir and not os.path.exists(file_dir):
+        os.makedirs(file_dir)
+        print("Directory", file_dir, "didn't exist, and was created", flush=True)
     file_handler = logging.FileHandler(filepath, "a")
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(log_formatter)

--- a/src/model/bucketed_embedding.py
+++ b/src/model/bucketed_embedding.py
@@ -9,4 +9,5 @@ class BucketedEmbedding(nn.Embedding):
         super(BucketedEmbedding, self).__init__(real_num_embeddings, *args, **kwargs)
 
     def forward(self, indices):
-        return super(BucketedEmbedding, self).forward(indices.div(self.bucket_size))
+        x = super(BucketedEmbedding, self).forward(indices // self.bucket_size)
+        return x.squeeze(0) if x.ndim > 2 else x

--- a/src/model/bucketed_embedding.py
+++ b/src/model/bucketed_embedding.py
@@ -10,4 +10,4 @@ class BucketedEmbedding(nn.Embedding):
 
     def forward(self, indices):
         x = super(BucketedEmbedding, self).forward(indices // self.bucket_size)
-        return x.squeeze(0) if x.ndim > 2 else x
+        return x.unsqueeze_(0) if x.ndim < 2 else x

--- a/src/model/dqn/base.py
+++ b/src/model/dqn/base.py
@@ -119,6 +119,7 @@ class DQN(object):
 
     def get_var(self, x):
         """Move a tensor to a CPU / GPU variable."""
+        x = x.detach()
         return x.cuda() if self.cuda else x
 
     def reset(self):
@@ -183,8 +184,8 @@ class DQN(object):
         return screens, variables, features, actions, rewards, isfinal
 
     def register_loss(self, loss_history, loss_sc, loss_gf):
-        loss_history['dqn_loss'].append(loss_sc.data.cpu().numpy())
-        loss_history['gf_loss'].append(loss_gf.data.cpu().numpy()
+        loss_history['dqn_loss'].append(loss_sc.cpu().item())
+        loss_history['gf_loss'].append(loss_gf.cpu().item()
                                        if self.n_features else 0)
 
     def next_action(self, last_states, save_graph=False):

--- a/src/model/dqn/base.py
+++ b/src/model/dqn/base.py
@@ -119,7 +119,6 @@ class DQN(object):
 
     def get_var(self, x):
         """Move a tensor to a CPU / GPU variable."""
-        x = x.detach()
         return x.cuda() if self.cuda else x
 
     def reset(self):

--- a/src/model/dqn/base.py
+++ b/src/model/dqn/base.py
@@ -1,7 +1,6 @@
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
 from logging import getLogger
 
 from ...utils import bool_flag
@@ -205,7 +204,7 @@ class DQN(object):
             if pred_features is not None:
                 assert pred_features.size() == (1, seq_len, self.module.n_features)
                 pred_features = pred_features[0, -1]
-        action_id = scores.data.max(0)[1]
+        action_id = scores.data.max(0)[1].item()
         self.pred_features = pred_features
         return action_id
 

--- a/src/model/dqn/base.py
+++ b/src/model/dqn/base.py
@@ -78,7 +78,7 @@ class DQNModuleBase(nn.Module):
 
         # create state input
         if self.n_variables:
-            output = torch.cat([conv_output] + embeddings, 1)
+            output = torch.cat([conv_output] + embeddings, dim=1)
         else:
             output = conv_output
 
@@ -120,7 +120,7 @@ class DQN(object):
 
     def get_var(self, x):
         """Move a tensor to a CPU / GPU variable."""
-        x = Variable(x)
+        x = x.detach()
         return x.cuda() if self.cuda else x
 
     def reset(self):
@@ -185,8 +185,8 @@ class DQN(object):
         return screens, variables, features, actions, rewards, isfinal
 
     def register_loss(self, loss_history, loss_sc, loss_gf):
-        loss_history['dqn_loss'].append(loss_sc.data[0])
-        loss_history['gf_loss'].append(loss_gf.data[0]
+        loss_history['dqn_loss'].append(loss_sc.data.cpu().numpy())
+        loss_history['gf_loss'].append(loss_gf.data.cpu().numpy()
                                        if self.n_features else 0)
 
     def next_action(self, last_states, save_graph=False):
@@ -205,7 +205,7 @@ class DQN(object):
             if pred_features is not None:
                 assert pred_features.size() == (1, seq_len, self.module.n_features)
                 pred_features = pred_features[0, -1]
-        action_id = scores.data.max(0)[1][0]
+        action_id = scores.data.max(0)[1]
         self.pred_features = pred_features
         return action_id
 

--- a/src/model/dqn/feedforward.py
+++ b/src/model/dqn/feedforward.py
@@ -21,9 +21,6 @@ class DQNModuleFeedforward(DQNModuleBase):
         """
 
         batch_size = x_screens.size(0)
-
-        for x in x_variables:
-            x.unsqueeze_(0)
         
         assert x_screens.ndimension() == 4
         assert len(x_variables) == self.n_variables

--- a/src/model/dqn/feedforward.py
+++ b/src/model/dqn/feedforward.py
@@ -23,8 +23,9 @@ class DQNModuleFeedforward(DQNModuleBase):
         assert x_screens.ndimension() == 4
         assert len(x_variables) == self.n_variables
 
-        #assert all(x.ndimension() == 0 and len(list(x.size())) == batch_size
-        #            for x in x_variables)
+        if batch_size > 1:
+            assert all(x.ndimension() == 1 and x.size(0) == batch_size for x in x_variables), \
+                f"{[(x.ndimension(), x.size(), x) for x in x_variables]} {batch_size}"
 
         # state input (screen / depth / labels buffer + variables)
         state_input, output_gf = self.base_forward(x_screens, x_variables)
@@ -82,7 +83,7 @@ class DQNFeedforward(DQN):
         )
 
         # dqn loss
-        loss_sc = self.loss_fn_sc(scores1, scores2)
+        loss_sc = self.loss_fn_sc(scores1, scores2.detach())
 
         # game features loss
         loss_gf = 0

--- a/src/model/dqn/feedforward.py
+++ b/src/model/dqn/feedforward.py
@@ -84,7 +84,7 @@ class DQNFeedforward(DQN):
         )
 
         # dqn loss
-        loss_sc = self.loss_fn_sc(scores1, scores2.detach())
+        loss_sc = self.loss_fn_sc(scores1, scores2)
 
         # game features loss
         loss_gf = 0

--- a/src/model/dqn/feedforward.py
+++ b/src/model/dqn/feedforward.py
@@ -1,8 +1,6 @@
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
 from .base import DQNModuleBase, DQN
-
 
 class DQNModuleFeedforward(DQNModuleBase):
 

--- a/src/model/dqn/recurrent.py
+++ b/src/model/dqn/recurrent.py
@@ -127,7 +127,7 @@ class DQNRecurrent(DQN):
         # dqn loss
         loss_sc = self.loss_fn_sc(
             scores1.view(batch_size, -1)[:, -self.params.n_rec_updates:],
-            torch.Tensor(scores2.data[:, -self.params.n_rec_updates:])
+            scores2[:, -self.params.n_rec_updates:]
         )
 
         # game features loss

--- a/src/model/dqn/recurrent.py
+++ b/src/model/dqn/recurrent.py
@@ -127,7 +127,7 @@ class DQNRecurrent(DQN):
         # dqn loss
         loss_sc = self.loss_fn_sc(
             scores1.view(batch_size, -1)[:, -self.params.n_rec_updates:],
-            scores2[:, -self.params.n_rec_updates:]
+            scores2.detach()[:, -self.params.n_rec_updates:]
         )
 
         # game features loss

--- a/src/model/utils.py
+++ b/src/model/utils.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
 from logging import getLogger
 from .bucketed_embedding import BucketedEmbedding
 
@@ -76,7 +75,7 @@ def build_CNN_network(module, params):
     ]))
 
     # get the size of the convolution network output
-    x = Variable(torch.FloatTensor(1, in_channels, height, width).zero_())
+    x = torch.FloatTensor(1, in_channels, height, width).zero_()
     module.conv_output_dim = module.conv(x).nelement()
 
 

--- a/src/replay_memory.py
+++ b/src/replay_memory.py
@@ -18,7 +18,7 @@ class ReplayMemory:
             self.features = np.zeros((max_size, n_features), dtype=np.int32)
         self.actions = np.zeros(max_size, dtype=np.int32)
         self.rewards = np.zeros(max_size, dtype=np.float32)
-        self.isfinal = np.zeros(max_size, dtype=np.bool)
+        self.isfinal = np.zeros(max_size, dtype=bool)
 
     @property
     def size(self):

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -59,8 +59,8 @@ class Trainer(object):
             self.n_iter += 1
 
             if self.game.is_final():
-                self.game.reset()     # dead or end of episode
-                self.network.reset()  # reset internal state (RNNs only)
+                self.game.new_episode()  # dead or end of episode
+                self.network.reset()     # reset internal state (RNNs only)
 
             self.game.observe_state(self.params, last_states)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -90,7 +90,7 @@ def get_optimizer(s):
         raise Exception('Unknown optimization method: "%s"' % method)
 
     # check that we give good parameters to the optimizer
-    expected_args = inspect.getargspec(optim_fn.__init__)[0]
+    expected_args = inspect.getfullargspec(optim_fn.__init__)[0]
     assert expected_args[:2] == ['self', 'params']
     if not all(k in expected_args[2:] for k in optim_params.keys()):
         raise Exception('Unexpected parameters: expected "%s", received "%s"' %


### PR DESCRIPTION
### Purpose of this fork:
Updated the code to support reasonable versions of PyTorch, NumPy and Python > 3.10, this may not be a clean fix but should get the code running again. Note that NumPy 2.x requires ViZDoom 1.2.4 and this config has not been tested, but at a glance there shouldn't cause a problem.

### Tested on two environments:
- Windows 11 / Python 3.12.3 / PyTorch 2.3.1 / NumPy 1.26.4 / ViZDoom 1.2.3
- Ubuntu 20.04 / Python 3.12.3 / PyTorch 2.6.0 / NumPy 1.26.4 / ViZDoom 1.2.3